### PR TITLE
Fix set _prefix from url

### DIFF
--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -71,6 +71,10 @@ export class QdrantClient {
                         `url is ${url}, prefix is ${parsedUrl.pathname}`,
                 );
             }
+            
+            if (parsedUrl.pathname !== '/') {
+                this._prefix = parsedUrl.pathname;
+            }
         } else {
             this._port = port;
             this._host = host ?? '127.0.0.1';


### PR DESCRIPTION
just noticed when setting the client from the url, the _prefix is not set