### PR TITLE
feat: Add badge for monthly download stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     <a href="https://github.com/qdrant/qdrant-client/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-success" alt="Apache 2.0 License"></a>
     <a href="https://qdrant.to/discord"><img src="https://img.shields.io/badge/Discord-Qdrant-5865F2.svg?logo=discord" alt="Discord"></a>
     <a href="https://qdrant.to/roadmap"><img src="https://img.shields.io/badge/Roadmap-2023-bc1439.svg" alt="Roadmap 2023"></a>
+    <a href="https://www.npmjs.com/package/@qdrant/js-client-rest"><img src="https://img.shields.io/npm/dm/@qdrant/js-client-rest" alt="Monthly download stats"></a>
 </p>
 
 # JavaScript Qdrant SDK

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/qdrant/qdrant-client/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-success" alt="Apache 2.0 License"></a>
     <a href="https://qdrant.to/discord"><img src="https://img.shields.io/badge/Discord-Qdrant-5865F2.svg?logo=discord" alt="Discord"></a>
     <a href="https://qdrant.to/roadmap"><img src="https://img.shields.io/badge/Roadmap-2023-bc1439.svg" alt="Roadmap 2023"></a>
-    <a href="https://www.npmjs.com/package/@qdrant/js-client-rest"><img src="https://img.shields.io/npm/dm/@qdrant/js-client-rest" alt="Monthly download stats"></a>
+    <a href="https://www.npmjs.com/search?q=%40qdrant%2Fjs-client"><img src="https://img.shields.io/endpoint?url=https://runkit.io/kshivendu/npm-download-stats/1.0.0?packages=@qdrant/js-client-grpc,@qdrant/js-client-rest" alt="Monthly download stats"></a>
 </p>
 
 # JavaScript Qdrant SDK


### PR DESCRIPTION
Add a badge for monthly download stats. 29k/month is a decently good number and will attract more developers to try out Qdrant :)

I created a similar PR for Python as well: https://github.com/qdrant/qdrant-client/pull/250

- https://img.shields.io/npm/dm/@qdrant/js-client-rest -> Monthly
- https://img.shields.io/npm/dw/@qdrant/js-client-rest -> Weekly
