### PR TITLE
refactor: parse default http ports in url, fixes #59

### DIFF
--- a/packages/js-client-grpc/src/qdrant-client.ts
+++ b/packages/js-client-grpc/src/qdrant-client.ts
@@ -47,7 +47,9 @@ export class QdrantClient {
             }
             const parsedUrl = new URL(url);
             this._host = parsedUrl.hostname;
-            this._port = parsedUrl.port ? Number(parsedUrl.port) : port;
+            const getPort = (url: string): number | null =>
+                url.includes(':443') ? 443 : url.includes(':80') ? 80 : port;
+            this._port = parsedUrl.port ? Number(parsedUrl.port) : getPort(url);
             this._scheme = parsedUrl.protocol.replace(':', '');
 
             if (this._prefix.length > 0 && parsedUrl.pathname !== '/') {

--- a/packages/js-client-grpc/tests/unit/qdrant-client.test.ts
+++ b/packages/js-client-grpc/tests/unit/qdrant-client.test.ts
@@ -41,6 +41,22 @@ test('QdrantClient()', () => {
     // @ts-expect-error ts(2341)
     expect(client._restUri).toBe('http://localhost:6334/custom');
 
+    client = new QdrantClient({url: 'https://localhost:443'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('https://localhost:443');
+
+    client = new QdrantClient({url: 'https://localhost'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('https://localhost:6334');
+
+    client = new QdrantClient({url: 'http://localhost:80'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('http://localhost:80');
+
+    client = new QdrantClient({url: 'http://localhost:80', prefix: 'custom'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('http://localhost:80/custom');
+
     expect(() => new QdrantClient({url: 'my-domain.com'})).toThrow(QdrantClientConfigError);
 
     expect(() => new QdrantClient({url: 'my-domain.com:80'})).toThrow(QdrantClientConfigError);

--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -62,7 +62,9 @@ export class QdrantClient {
             }
             const parsedUrl = new URL(url);
             this._host = parsedUrl.hostname;
-            this._port = parsedUrl.port ? Number(parsedUrl.port) : port;
+            const getPort = (url: string): number | null =>
+                url.includes(':443') ? 443 : url.includes(':80') ? 80 : port;
+            this._port = parsedUrl.port ? Number(parsedUrl.port) : getPort(url);
             this._scheme = parsedUrl.protocol.replace(':', '');
 
             if (this._prefix.length > 0 && parsedUrl.pathname !== '/') {

--- a/packages/js-client-rest/tests/unit/qdrant-client.test.ts
+++ b/packages/js-client-rest/tests/unit/qdrant-client.test.ts
@@ -41,6 +41,22 @@ test('QdrantClient()', () => {
     // @ts-expect-error ts(2341)
     expect(client._restUri).toBe('http://localhost:6333/custom');
 
+    client = new QdrantClient({url: 'https://localhost:443'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('https://localhost:443');
+
+    client = new QdrantClient({url: 'https://localhost'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('https://localhost:6333');
+
+    client = new QdrantClient({url: 'http://localhost:80'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('http://localhost:80');
+
+    client = new QdrantClient({url: 'http://localhost:80', prefix: 'custom'});
+    // @ts-expect-error ts(2341)
+    expect(client._restUri).toBe('http://localhost:80/custom');
+
     expect(() => new QdrantClient({url: 'my-domain.com'})).toThrow(QdrantClientConfigError);
 
     expect(() => new QdrantClient({url: 'my-domain.com:80'})).toThrow(QdrantClientConfigError);


### PR DESCRIPTION
This change correctly parses default http ports in url for rest and grpc packages.