### PR TITLE
Version bump v1.8.1

### DIFF
--- a/packages/js-client-rest/CHANGELOG.md
+++ b/packages/js-client-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @qdrant/js-client-rest
 
+## 1.8.1
+
+### Patch Changes
+
+-   [#67](https://github.com/qdrant/qdrant-js/pull/67) Update dependencies for @qdrant/openapi-typescript-fetch to 1.2.6
+
 ## 1.8.0
 
 ### Minor Changes

--- a/packages/js-client-rest/package.json
+++ b/packages/js-client-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qdrant/js-client-rest",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "engines": {
         "node": ">=18.0.0",
         "pnpm": ">=8"

--- a/packages/qdrant-js/CHANGELOG.md
+++ b/packages/qdrant-js/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @qdrant/qdrant-js
 
+## 1.8.1
+
+### Patch Changes
+
+-   [#67](https://github.com/qdrant/qdrant-js/pull/67) Update dependencies for @qdrant/openapi-typescript-fetch to 1.2.6
+-   Updated dependencie []:
+    -   @qdrant/js-client-rest@1.8.1
+
 ## 1.8.0
 
 ### Minor Changes

--- a/packages/qdrant-js/package.json
+++ b/packages/qdrant-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qdrant/qdrant-js",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "engines": {
         "node": ">=18.0.0",
         "pnpm": ">=8"
@@ -57,7 +57,7 @@
         "clean": "rimraf ./dist"
     },
     "dependencies": {
-        "@qdrant/js-client-rest": "workspace:1.8.0",
+        "@qdrant/js-client-rest": "workspace:1.8.1",
         "@qdrant/js-client-grpc": "workspace:1.8.0"
     },
     "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         specifier: workspace:1.8.0
         version: link:../js-client-grpc
       '@qdrant/js-client-rest':
-        specifier: workspace:1.8.0
+        specifier: workspace:1.8.1
         version: link:../js-client-rest
       typescript:
         specifier: '>=4.1'


### PR DESCRIPTION

-   [#67](https://github.com/qdrant/qdrant-js/pull/67) Update dependencies for @qdrant/openapi-typescript-fetch to 1.2.6
-   Updated dependencie []:
    -   @qdrant/js-client-rest@1.8.1
