### PR TITLE
Fix error handling example in js-client-rest/README.md

### DIFF
--- a/packages/js-client-rest/README.md
+++ b/packages/js-client-rest/README.md
@@ -66,7 +66,7 @@ try {
     // ...
 } catch (e) {
     // check which operation threw the exception
-    if (e instanceof client.getCollection.Error) {
+    if (e instanceof client.api('collections').getCollection.Error) {
         // get discriminated union error { status, data }
         const error = e.getActualType();
         // sort case's logic


### PR DESCRIPTION
The code provided in the example for typing errors does not work. `getCollection` function in `client` does not have `Error`.