### PR TITLE
Fix unit documentation for timeout parameter in qdrant-client.ts

### DIFF
--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -122,7 +122,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @returns List of search responses
      */
     async searchBatch(
@@ -186,7 +186,7 @@ export class QdrantClient {
      *              - 'majority' - query all replicas, but return values present in the majority of replicas
      *              - 'quorum' - query the majority of replicas, return values present in all of them
      *              - 'all' - query all replicas, and return values present in all replicas
-     *      - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *      - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @example
      *     // Search with filter
      *     client.search(
@@ -255,7 +255,7 @@ export class QdrantClient {
      *             - 'majority' - query all replicas, but return values present in the majority of replicas
      *             - 'quorum' - query the majority of replicas, return values present in all of them
      *             - 'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @returns List of recommend responses
      */
     async recommendBatch(
@@ -355,7 +355,7 @@ export class QdrantClient {
      *         - 'majority' - query all replicas, but return values present in the majority of replicas
      *         - 'quorum' - query the majority of replicas, return values present in all of them
      *         - 'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @returns List of recommended points with similarity scores.
      */
     async recommend(
@@ -585,7 +585,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - shard_key: Specify in which shards to look for the points, if not specified - look in all shards
      *     - vector: query search vector
      *     - filter: Look only for points which satisfies this conditions
@@ -643,7 +643,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - shard_key: Specify in which shards to look for the points, if not specified - look in all shards
      *     - positive: Look for vectors closest to those
      *     - negative: Try to avoid vectors like this
@@ -1593,7 +1593,7 @@ export class QdrantClient {
      *     - shards_number: How many shards to create for this key If not specified, will use the default value from config
      *     - replication_factor: How many replicas to create for each shard If not specified, will use the default value from config
      *     - placement: Placement of shards for this key List of peer ids, that can be used to place shards for this key If not specified, will be randomly placed among all peers
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @returns Operation result
      */
     async createShardKey(
@@ -1622,7 +1622,7 @@ export class QdrantClient {
      * @param collection_name Name of the collection
      * @param {object} args -
      *     - shard_key: Specify in which shards to look for the points, if not specified - look in all shards
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      * @returns Operation result
      */
     async deleteShardKey(
@@ -1651,7 +1651,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - shard_key: Specify in which shards to look for the points, if not specified - look in all shards
      *     - target: Look for vectors closest to this. When using the target (with or without context), the integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target.
      *     - context: Pairs of { positive, negative } examples to constrain the search. When using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair. Since the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0. For discovery search (when including a target), the context part of the score for each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, and -1 otherwise.
@@ -1711,7 +1711,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - searches: List of searches
      * @returns Operation result
      */
@@ -1764,7 +1764,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - shard_key: Specify in which shards to look for the points, if not specified - look in all shards.
      *     - prefetch: Sub-requests to perform first. If present, the query will be performed on the results of the prefetch(es).
      *     - query: Query to perform. If missing without prefetches, returns points ordered by their IDs.
@@ -1829,7 +1829,7 @@ export class QdrantClient {
      *             'majority' - query all replicas, but return values present in the majority of replicas
      *             'quorum' - query the majority of replicas, return values present in all of them
      *             'all' - query all replicas, and return values present in all replicas
-     *     - timeout: If set, overrides global timeout setting for this request. Unit is seconds.
+     *     - timeout: If set, overrides global timeout setting for this request. Unit is milliseconds.
      *     - searches: List of queries
      * @returns Operation result
      */


### PR DESCRIPTION
Documentation said "seconds", but is actually milliseconds.

See qdrant-client.ts:14
> "* Local timeout for requests [...] - Default 300 seconds"

and qdrant-client.ts:39
> " constructor({url, [...], timeout = 300_000, ...args}: [...]"