### PR TITLE
Check compatibility between server and client versions

### DIFF
--- a/packages/js-client-grpc/src/client-version.ts
+++ b/packages/js-client-grpc/src/client-version.ts
@@ -19,16 +19,9 @@ export const ClientVersion = {
 
         let major = undefined;
         let minor = undefined;
-        try {
-            [major, minor] = version.split('.', 2);
-            major = major.trim();
-            minor = minor.trim();
-            major = parseInt(major, 10);
-            minor = parseInt(minor, 10);
-        } catch (error) {
-            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
-        }
-
+        [major, minor] = version.split('.', 2);
+        major = parseInt(major, 10);
+        minor = parseInt(minor, 10);
         if (isNaN(major) || isNaN(minor)) {
             throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
         }
@@ -45,30 +38,19 @@ export const ClientVersion = {
      * @returns True if compatible, otherwise false.
      */
     isCompatible(clientVersion: string, serverVersion: string): boolean {
-        if (!clientVersion) {
-            console.debug(`Unable to compare with client version: null`);
+        if (!clientVersion || !serverVersion) {
+            console.debug(
+                `Unable to compare versions with null values. Client: ${clientVersion}, Server: ${serverVersion}`,
+            );
             return false;
         }
 
-        if (!serverVersion) {
-            console.debug(`Unable to compare with server version: null`);
-            return false;
-        }
-
-        if (clientVersion === serverVersion) {
-            return true;
-        }
+        if (clientVersion === serverVersion) return true;
 
         try {
-            const parsedClientVersion = ClientVersion.parseVersion(clientVersion);
-            const parsedServerVersion = ClientVersion.parseVersion(serverVersion);
-
-            const majorDiff = Math.abs(parsedClientVersion.major - parsedServerVersion.major);
-            if (majorDiff >= 1) {
-                return false;
-            }
-
-            return Math.abs(parsedClientVersion.minor - parsedServerVersion.minor) <= 1;
+            const client = ClientVersion.parseVersion(clientVersion);
+            const server = ClientVersion.parseVersion(serverVersion);
+            return client.major === server.major && Math.abs(client.minor - server.minor) <= 1;
         } catch (error) {
             console.debug(`Unable to compare versions: ${error as string}`);
             return false;

--- a/packages/js-client-grpc/src/client-version.ts
+++ b/packages/js-client-grpc/src/client-version.ts
@@ -1,1 +1,77 @@
 export const PACKAGE_VERSION = '1.12.0';
+
+interface Version {
+    major: number;
+    minor: number;
+}
+
+export const ClientVersion = {
+    /**
+     * Parses a version string into a structured Version object.
+     * @param version - The version string to parse (e.g., "1.2.3").
+     * @returns A Version object.
+     * @throws If the version format is invalid.
+     */
+    parseVersion(version: string): Version {
+        if (!version) {
+            throw new Error('Version is null');
+        }
+
+        let major = undefined;
+        let minor = undefined;
+        try {
+            [major, minor] = version.split('.', 2);
+            major = major.trim();
+            minor = minor.trim();
+            major = parseInt(major, 10);
+            minor = parseInt(minor, 10);
+        } catch (error) {
+            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
+        }
+
+        if (isNaN(major) || isNaN(minor)) {
+            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
+        }
+        return {
+            major,
+            minor,
+        };
+    },
+
+    /**
+     * Checks if the client version is compatible with the server version.
+     * @param clientVersion - The client version string.
+     * @param serverVersion - The server version string.
+     * @returns True if compatible, otherwise false.
+     */
+    isCompatible(clientVersion: string, serverVersion: string): boolean {
+        if (!clientVersion) {
+            console.debug(`Unable to compare with client version: null`);
+            return false;
+        }
+
+        if (!serverVersion) {
+            console.debug(`Unable to compare with server version: null`);
+            return false;
+        }
+
+        if (clientVersion === serverVersion) {
+            return true;
+        }
+
+        try {
+            const parsedClientVersion = ClientVersion.parseVersion(clientVersion);
+            const parsedServerVersion = ClientVersion.parseVersion(serverVersion);
+
+            const majorDiff = Math.abs(parsedClientVersion.major - parsedServerVersion.major);
+            if (majorDiff >= 1) {
+                return false;
+            }
+
+            return Math.abs(parsedClientVersion.minor - parsedServerVersion.minor) <= 1;
+        } catch (error) {
+            console.debug(`Unable to compare versions: ${error as string}`);
+            return false;
+        }
+    },
+};

--- a/packages/js-client-grpc/src/qdrant-client.ts
+++ b/packages/js-client-grpc/src/qdrant-client.ts
@@ -1,7 +1,6 @@
 import {GrpcClients, createApis} from './api-client.js';
 import {QdrantClientConfigError} from './errors.js';
 import {ClientVersion, PACKAGE_VERSION} from './client-version.js';
-import {HealthCheckRequest} from './proto/qdrant_pb.js';
 
 export type QdrantClientParams = {
     port?: number | null;
@@ -86,7 +85,7 @@ export class QdrantClient {
 
         if (checkCompatibility) {
             this._grcpClients.service
-                .healthCheck(HealthCheckRequest)
+                .healthCheck({})
                 .then((response) => {
                     const serverVersion = response.version;
                     if (!ClientVersion.isCompatible(PACKAGE_VERSION, serverVersion)) {

--- a/packages/js-client-grpc/src/qdrant-client.ts
+++ b/packages/js-client-grpc/src/qdrant-client.ts
@@ -11,7 +11,7 @@ export type QdrantClientParams = {
     url?: string;
     host?: string;
     timeout?: number;
-    check_compatibility?: boolean;
+    checkCompatibility?: boolean;
 };
 
 export class QdrantClient {
@@ -31,7 +31,7 @@ export class QdrantClient {
         prefix,
         port = 6334,
         timeout = 300_000,
-        check_compatibility = true,
+        checkCompatibility = true,
     }: QdrantClientParams = {}) {
         this._https = https ?? typeof apiKey === 'string';
         this._scheme = this._https ? 'https' : 'http';
@@ -84,7 +84,7 @@ export class QdrantClient {
 
         this._grcpClients = createApis(this._restUri, {apiKey, timeout});
 
-        if (check_compatibility) {
+        if (checkCompatibility) {
             this._grcpClients.service
                 .healthCheck(HealthCheckRequest)
                 .then((response) => {

--- a/packages/js-client-grpc/tests/unit/client-version.test.ts
+++ b/packages/js-client-grpc/tests/unit/client-version.test.ts
@@ -1,7 +1,47 @@
 import {test, expect} from 'vitest';
 import {version} from '../../package.json';
-import {PACKAGE_VERSION} from '../../src/client-version.js';
+import {PACKAGE_VERSION, ClientVersion} from '../../src/client-version.js';
 
 test('Client version is consistent', () => {
     expect(version).toBe(PACKAGE_VERSION);
+});
+
+test.each([
+    {input: '1.2', expected: {major: 1, minor: 2}},
+    {input: '1.2.3', expected: {major: 1, minor: 2}},
+])('parseVersion($input) should return $expected', ({input, expected}) => {
+    const result = ClientVersion.parseVersion(input);
+    expect(result).toEqual(expected);
+});
+
+test.each([
+    {input: '', error: 'Version is null'},
+    {input: '1', error: 'Unable to parse version, expected format: x.y[.z], found: 1'},
+    {input: '1.', error: 'Unable to parse version, expected format: x.y[.z], found: 1.'},
+    {input: '.1', error: 'Unable to parse version, expected format: x.y[.z], found: .1'},
+    {input: '.1.', error: 'Unable to parse version, expected format: x.y[.z], found: .1.'},
+    {input: '1.a.1', error: 'Unable to parse version, expected format: x.y[.z], found: 1.a.1'},
+    {input: 'a.1.1', error: 'Unable to parse version, expected format: x.y[.z], found: a.1.1'},
+])('parseVersion($input) should throw error $error', ({input, error}) => {
+    expect(() => ClientVersion.parseVersion(input)).toThrow(error);
+});
+
+test.each([
+    {client: '1.9.3.dev0', server: '2.8.1.dev12-something', expected: false},
+    {client: '1.9', server: '2.8', expected: false},
+    {client: '1', server: '2', expected: false},
+    {client: '1.9.0', server: '2.9.0', expected: false},
+    {client: '1.1.0', server: '1.2.9', expected: true},
+    {client: '1.2.7', server: '1.1.8.dev0', expected: true},
+    {client: '1.2.1', server: '1.2.29', expected: true},
+    {client: '1.2.0', server: '1.2.0', expected: true},
+    {client: '1.2.0', server: '1.4.0', expected: false},
+    {client: '1.4.0', server: '1.2.0', expected: false},
+    {client: '1.9.0', server: '3.7.0', expected: false},
+    {client: '3.0.0', server: '1.0.0', expected: false},
+    {client: '', server: '1.0.0', expected: false},
+    {client: '1.0.0', server: '', expected: false},
+])('isCompatible($client, $server) should return $expected', ({client, server, expected}) => {
+    const result = ClientVersion.isCompatible(client, server);
+    expect(result).toEqual(expected);
 });

--- a/packages/js-client-rest/src/client-version.ts
+++ b/packages/js-client-rest/src/client-version.ts
@@ -19,16 +19,9 @@ export const ClientVersion = {
 
         let major = undefined;
         let minor = undefined;
-        try {
-            [major, minor] = version.split('.', 2);
-            major = major.trim();
-            minor = minor.trim();
-            major = parseInt(major, 10);
-            minor = parseInt(minor, 10);
-        } catch (error) {
-            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
-        }
-
+        [major, minor] = version.split('.', 2);
+        major = parseInt(major, 10);
+        minor = parseInt(minor, 10);
         if (isNaN(major) || isNaN(minor)) {
             throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
         }
@@ -45,30 +38,19 @@ export const ClientVersion = {
      * @returns True if compatible, otherwise false.
      */
     isCompatible(clientVersion: string, serverVersion: string): boolean {
-        if (!clientVersion) {
-            console.debug(`Unable to compare with client version: null`);
+        if (!clientVersion || !serverVersion) {
+            console.debug(
+                `Unable to compare versions with null values. Client: ${clientVersion}, Server: ${serverVersion}`,
+            );
             return false;
         }
 
-        if (!serverVersion) {
-            console.debug(`Unable to compare with server version: null`);
-            return false;
-        }
-
-        if (clientVersion === serverVersion) {
-            return true;
-        }
+        if (clientVersion === serverVersion) return true;
 
         try {
-            const parsedClientVersion = ClientVersion.parseVersion(clientVersion);
-            const parsedServerVersion = ClientVersion.parseVersion(serverVersion);
-
-            const majorDiff = Math.abs(parsedClientVersion.major - parsedServerVersion.major);
-            if (majorDiff >= 1) {
-                return false;
-            }
-
-            return Math.abs(parsedClientVersion.minor - parsedServerVersion.minor) <= 1;
+            const client = ClientVersion.parseVersion(clientVersion);
+            const server = ClientVersion.parseVersion(serverVersion);
+            return client.major === server.major && Math.abs(client.minor - server.minor) <= 1;
         } catch (error) {
             console.debug(`Unable to compare versions: ${error as string}`);
             return false;

--- a/packages/js-client-rest/src/client-version.ts
+++ b/packages/js-client-rest/src/client-version.ts
@@ -1,1 +1,77 @@
 export const PACKAGE_VERSION = '1.12.0';
+
+interface Version {
+    major: number;
+    minor: number;
+}
+
+export const ClientVersion = {
+    /**
+     * Parses a version string into a structured Version object.
+     * @param version - The version string to parse (e.g., "1.2.3").
+     * @returns A Version object.
+     * @throws If the version format is invalid.
+     */
+    parseVersion(version: string): Version {
+        if (!version) {
+            throw new Error('Version is null');
+        }
+
+        let major = undefined;
+        let minor = undefined;
+        try {
+            [major, minor] = version.split('.', 2);
+            major = major.trim();
+            minor = minor.trim();
+            major = parseInt(major, 10);
+            minor = parseInt(minor, 10);
+        } catch (error) {
+            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
+        }
+
+        if (isNaN(major) || isNaN(minor)) {
+            throw new Error(`Unable to parse version, expected format: x.y[.z], found: ${version}`);
+        }
+        return {
+            major,
+            minor,
+        };
+    },
+
+    /**
+     * Checks if the client version is compatible with the server version.
+     * @param clientVersion - The client version string.
+     * @param serverVersion - The server version string.
+     * @returns True if compatible, otherwise false.
+     */
+    isCompatible(clientVersion: string, serverVersion: string): boolean {
+        if (!clientVersion) {
+            console.debug(`Unable to compare with client version: null`);
+            return false;
+        }
+
+        if (!serverVersion) {
+            console.debug(`Unable to compare with server version: null`);
+            return false;
+        }
+
+        if (clientVersion === serverVersion) {
+            return true;
+        }
+
+        try {
+            const parsedClientVersion = ClientVersion.parseVersion(clientVersion);
+            const parsedServerVersion = ClientVersion.parseVersion(serverVersion);
+
+            const majorDiff = Math.abs(parsedClientVersion.major - parsedServerVersion.major);
+            if (majorDiff >= 1) {
+                return false;
+            }
+
+            return Math.abs(parsedClientVersion.minor - parsedServerVersion.minor) <= 1;
+        } catch (error) {
+            console.debug(`Unable to compare versions: ${error as string}`);
+            return false;
+        }
+    },
+};

--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -28,7 +28,7 @@ export type QdrantClientParams = {
     /**
      * Check compatibility with the server version. Default: `true`
      */
-    check_compatibility?: boolean;
+    checkCompatibility?: boolean;
 };
 
 export class QdrantClient {
@@ -48,7 +48,7 @@ export class QdrantClient {
         prefix,
         port = 6333,
         timeout = 300_000,
-        check_compatibility = true,
+        checkCompatibility = true,
         ...args
     }: QdrantClientParams = {}) {
         this._https = https ?? typeof apiKey === 'string';
@@ -114,7 +114,7 @@ export class QdrantClient {
 
         this._openApiClient = createApis(this._restUri, restArgs);
 
-        if (check_compatibility) {
+        if (checkCompatibility) {
             this._openApiClient.service
                 .root({})
                 .then((response) => {

--- a/packages/js-client-rest/tests/unit/client-version.test.ts
+++ b/packages/js-client-rest/tests/unit/client-version.test.ts
@@ -1,7 +1,47 @@
 import {test, expect} from 'vitest';
 import {version} from '../../package.json';
-import {PACKAGE_VERSION} from '../../src/client-version.js';
+import {PACKAGE_VERSION, ClientVersion} from '../../src/client-version.js';
 
 test('Client version is consistent', () => {
     expect(version).toBe(PACKAGE_VERSION);
+});
+
+test.each([
+    {input: '1.2', expected: {major: 1, minor: 2}},
+    {input: '1.2.3', expected: {major: 1, minor: 2}},
+])('parseVersion($input) should return $expected', ({input, expected}) => {
+    const result = ClientVersion.parseVersion(input);
+    expect(result).toEqual(expected);
+});
+
+test.each([
+    {input: '', error: 'Version is null'},
+    {input: '1', error: 'Unable to parse version, expected format: x.y[.z], found: 1'},
+    {input: '1.', error: 'Unable to parse version, expected format: x.y[.z], found: 1.'},
+    {input: '.1', error: 'Unable to parse version, expected format: x.y[.z], found: .1'},
+    {input: '.1.', error: 'Unable to parse version, expected format: x.y[.z], found: .1.'},
+    {input: '1.a.1', error: 'Unable to parse version, expected format: x.y[.z], found: 1.a.1'},
+    {input: 'a.1.1', error: 'Unable to parse version, expected format: x.y[.z], found: a.1.1'},
+])('parseVersion($input) should throw error $error', ({input, error}) => {
+    expect(() => ClientVersion.parseVersion(input)).toThrow(error);
+});
+
+test.each([
+    {client: '1.9.3.dev0', server: '2.8.1.dev12-something', expected: false},
+    {client: '1.9', server: '2.8', expected: false},
+    {client: '1', server: '2', expected: false},
+    {client: '1.9.0', server: '2.9.0', expected: false},
+    {client: '1.1.0', server: '1.2.9', expected: true},
+    {client: '1.2.7', server: '1.1.8.dev0', expected: true},
+    {client: '1.2.1', server: '1.2.29', expected: true},
+    {client: '1.2.0', server: '1.2.0', expected: true},
+    {client: '1.2.0', server: '1.4.0', expected: false},
+    {client: '1.4.0', server: '1.2.0', expected: false},
+    {client: '1.9.0', server: '3.7.0', expected: false},
+    {client: '3.0.0', server: '1.0.0', expected: false},
+    {client: '', server: '1.0.0', expected: false},
+    {client: '1.0.0', server: '', expected: false},
+])('isCompatible($client, $server) should return $expected', ({client, server, expected}) => {
+    const result = ClientVersion.isCompatible(client, server);
+    expect(result).toEqual(expected);
 });


### PR DESCRIPTION
Send request to fetch server version in constructor and compare with client version.

Introduce a boolean param check_compatibility (true by default). If it is true -> check versions during client init and generate a warning if versions are not compatible. 

Compatible versions are the ones that differ by one, i.e client version 1.6.x is compatible with server versions 1.5.x and 1.7.x but not 1.4.x or 1.8.x.

