### PR TITLE
Upload artifact version up

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       - run: pnpm publish --no-git-checks --filter '!monorepo'
 
       - name: Archive npm failure logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: npm-logs


### PR DESCRIPTION
Upload artefacts were deprecated. This PR ups the version
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Checked that all `with:` in use are the same in v4.