### PR TITLE
fix release pnpm audit

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,8 +26,10 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
+          scope: "@qdrant"
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Node packages audit
         run: pnpm audit --prod

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.15.3
+          version: 8.15.9
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,6 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
+          version: 8.15.3
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,6 +30,9 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
+      - name: Check pnpm version
+        run: pnpm --version
+
       - name: Node packages audit
         run: pnpm audit --prod
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.15.9
+          version: 9.15.9
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -31,13 +31,10 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
-      - name: Check pnpm version
-        run: pnpm --version
-
       - name: Node packages audit
         run: pnpm audit --prod
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:
           CI: 1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,6 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 9.15.0
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -34,7 +33,7 @@ jobs:
       - name: Node packages audit
         run: pnpm audit --prod
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: pnpm install --frozen-lockfile
         env:
           CI: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
+          version: 9.15.9
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
PR fixes this release pipeline error
https://github.com/qdrant/qdrant-js/actions/runs/14594406658

The fix provides pnpm v9 in the release pipeline, like in the pull request pipeline. The previous release pipeline installed pnpm v8, which is obsolete. The latest is v10.

This PR also modifies the pull request pipeline to make it the same as release to catch problems like this on pull request CI, not on Release CI.