### PR TITLE
fix: use standard HTTP/HTTPS ports when not specified in URL Previous…

### DIFF
--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -80,8 +80,20 @@ export class QdrantClient {
             }
             const parsedUrl = new URL(url);
             this._host = parsedUrl.hostname;
-            this._port = parsedUrl.port ? Number(parsedUrl.port) : port;
             this._scheme = parsedUrl.protocol.replace(':', '');
+
+            if (parsedUrl.port) {
+                this._port = Number(parsedUrl.port);
+            } else {
+
+                if (this._scheme === 'https') {
+                    this._port = 443;
+                } else if (this._scheme === 'http') {
+                    this._port = 80;
+                } else {
+                    this._port = port;
+                }
+            }
 
             if (this._prefix.length > 0 && parsedUrl.pathname !== '/') {
                 throw new QdrantClientConfigError(


### PR DESCRIPTION
When a URL was provided without an explicit port, the client would fall back to the constructor's port parameter (default 6334), causing URLs like https://example.com to incorrectly use port 6334 instead of the standard HTTPS port 443. Now properly defaults to: - Port 443 for HTTPS URLs - Port 80 for HTTP URLs - Constructor port parameter for other protocols Fixes incorrect port resolution for standard HTTP/HTTPS URLs.

related issue: #94 