### PR TITLE
Optional gRPC channel compression

### DIFF
--- a/packages/js-client-grpc/src/api-client.ts
+++ b/packages/js-client-grpc/src/api-client.ts
@@ -53,16 +53,21 @@ function createClients(transport: Transport) {
 type CreateApisParams = {
     timeout: number;
     apiKey?: string;
-    useCompression: boolean;
+    compression: boolean | 'gzip';
 };
 
-export function createApis(baseUrl: string, {timeout, apiKey, useCompression}: CreateApisParams): GrpcClients {
-    // Use gzip compression by default
+export function createApis(baseUrl: string, {timeout, apiKey, compression}: CreateApisParams): GrpcClients {
     let sendCompression = undefined;
     let acceptCompression: Compression[] = [];
-    if (useCompression) {
-        sendCompression = compressionGzip;
-        acceptCompression = [compressionGzip];
+    switch (compression) {
+        // Use gzip compression by default
+        case true:
+        case 'gzip':
+            sendCompression = compressionGzip;
+            acceptCompression = [compressionGzip];
+            break;
+        default:
+            break;
     }
 
     const interceptors: Interceptor[] = [

--- a/packages/js-client-grpc/src/qdrant-client.ts
+++ b/packages/js-client-grpc/src/qdrant-client.ts
@@ -11,7 +11,7 @@ export type QdrantClientParams = {
     host?: string;
     timeout?: number;
     checkCompatibility?: boolean;
-    useCompression?: boolean;
+    compression?: boolean | 'gzip';
 };
 
 export class QdrantClient {
@@ -32,7 +32,7 @@ export class QdrantClient {
         port = 6334,
         timeout = 300_000,
         checkCompatibility = true,
-        useCompression = true,
+        compression = true,
     }: QdrantClientParams = {}) {
         this._https = https ?? typeof apiKey === 'string';
         this._scheme = this._https ? 'https' : 'http';
@@ -83,7 +83,7 @@ export class QdrantClient {
         const address = this._port ? `${this._host}:${this._port}` : this._host;
         this._restUri = `${this._scheme}://${address}${this._prefix}`;
 
-        this._grcpClients = createApis(this._restUri, {apiKey, timeout, useCompression});
+        this._grcpClients = createApis(this._restUri, {apiKey, timeout, compression});
 
         if (checkCompatibility) {
             this._grcpClients.service


### PR DESCRIPTION
Builds on top of #112, although not strictly needed for these changes.

Adds a `compression` parameter to the client params, such that the default `gzip` compression can be avoided.

Internally, the client can negotiate which compression the channel will use (for sending and accepting messages). This new setting sets both to gzip, or no compression at all.

Relates to qdrant/qdrant#7366: In internal testing with the repo shared in the issue, avg latency dropped from 115ms to 15ms by not de/compressing.