### PR TITLE
Generate provenance statement on release to increase security

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for provenance statement
     strategy:
       matrix:
         node-version: [18]


### PR DESCRIPTION
Following recent hacks on npm packages, it would be greatly appreciated if you could increase the trust level of the npm packages.

I added generation of provenance statements as outlined in this guide from npm: https://docs.npmjs.com/generating-provenance-statements