### PR TITLE
feat: Support for tracing ID headers

### DIFF
--- a/packages/js-client-grpc/src/api-client.ts
+++ b/packages/js-client-grpc/src/api-client.ts
@@ -7,6 +7,7 @@ import {Qdrant} from './proto/qdrant_pb.js';
 import {PACKAGE_VERSION} from './client-version.js';
 import {QdrantClientResourceExhaustedError} from './errors.js';
 import {Compression} from '@connectrpc/connect/protocol';
+import {getContextHeaders} from './context-headers.js';
 
 type Clients = {
     collections: Client<typeof Collections>;
@@ -99,6 +100,10 @@ export function createApis(baseUrl: string, {timeout, apiKey, compression, heade
             return next(req);
         });
     }
+    interceptors.push((next) => (req) => {
+        for (const [key, value] of Object.entries(getContextHeaders())) req.header.set(key, value);
+        return next(req);
+    });
     if (Number.isFinite(timeout)) {
         interceptors.push((next) => async (req) => {
             const controller = new AbortController();

--- a/packages/js-client-grpc/src/context-headers.ts
+++ b/packages/js-client-grpc/src/context-headers.ts
@@ -1,0 +1,15 @@
+let _current: Record<string, string> = {};
+
+export function withHeaders<T>(headers: Record<string, string>, fn: () => T): T {
+    const previous = _current;
+    _current = {...previous, ...headers};
+    try {
+        return fn();
+    } finally {
+        _current = previous;
+    }
+}
+
+export function getContextHeaders(): Record<string, string> {
+    return _current;
+}

--- a/packages/js-client-grpc/src/index.ts
+++ b/packages/js-client-grpc/src/index.ts
@@ -1,4 +1,5 @@
 export {QdrantClient, QdrantClientParams} from './qdrant-client.js';
+export {withHeaders} from './context-headers.js';
 export * from './errors.js';
 export {ConnectError, Code as ConnectErrorCode} from '@connectrpc/connect';
 export * from './proto/collections_pb.js';

--- a/packages/js-client-rest/package.json
+++ b/packages/js-client-rest/package.json
@@ -55,7 +55,7 @@
     },
     "dependencies": {
         "@qdrant/openapi-typescript-fetch": "1.2.6",
-        "undici": "^6.23.0"
+        "undici": "^6.24.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",

--- a/packages/js-client-rest/src/api-client.ts
+++ b/packages/js-client-rest/src/api-client.ts
@@ -9,6 +9,7 @@ import {
 import {RestArgs} from './types.js';
 import {createClientApi} from './openapi/generated_api_client.js';
 import {ClientApi} from './openapi/generated_client_type.js';
+import {getContextHeaders} from './context-headers.js';
 
 export type Client = ReturnType<typeof Fetcher.for<paths>>;
 
@@ -21,6 +22,14 @@ export type OpenApiClient = ReturnType<typeof createApis>;
 
 export function createClient(baseUrl: string, {headers, timeout, connections}: RestArgs): Client {
     const use: Middleware[] = [];
+    use.push((url, init, next) => {
+        const ctx = getContextHeaders();
+        const entries = Object.entries(ctx);
+        if (entries.length === 0) return next(url, init);
+        const merged = new Headers(init.headers as HeadersInit);
+        for (const [key, value] of entries) merged.set(key, value);
+        return next(url, {...init, headers: merged});
+    });
     if (Number.isFinite(timeout)) {
         use.push(async (url, init, next) => {
             const controller = new AbortController();

--- a/packages/js-client-rest/src/context-headers.ts
+++ b/packages/js-client-rest/src/context-headers.ts
@@ -1,0 +1,15 @@
+let _current: Record<string, string> = {};
+
+export function withHeaders<T>(headers: Record<string, string>, fn: () => T): T {
+    const previous = _current;
+    _current = {...previous, ...headers};
+    try {
+        return fn();
+    } finally {
+        _current = previous;
+    }
+}
+
+export function getContextHeaders(): Record<string, string> {
+    return _current;
+}

--- a/packages/js-client-rest/src/index.ts
+++ b/packages/js-client-rest/src/index.ts
@@ -1,3 +1,4 @@
 export {QdrantClient, QdrantClientParams} from './qdrant-client.js';
+export {withHeaders} from './context-headers.js';
 export {Schemas} from './types.js';
 export * from './errors.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: '>=4.7'
         version: 5.0.4
       undici:
-        specifier: ^6.23.0
-        version: 6.23.0
+        specifier: ^6.24.0
+        version: 6.24.1
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^24.1.0
@@ -1803,8 +1803,8 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
   uri-js@4.4.1:
@@ -3455,7 +3455,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.0
 
-  undici@6.23.0: {}
+  undici@6.24.1: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
Built on top of #125

```js
const results = await withHeaders({ 'x-request-id': 'abc-123' }, () =>
    client.query(...)
);
```

```js
// Nesting merges headers
withHeaders({ 'x-request-id': 'outer' }, () => {
    withHeaders({ 'x-tracing-id': 'inner' }, () => {
        // both x-request-id and x-tracing-id are sent
        client.query(...);
    });
});
```