### PR TITLE
feat: add allowUnsecureConnection flag to suppress warning (#119)

### DIFF
--- a/packages/js-client-grpc/src/qdrant-client.ts
+++ b/packages/js-client-grpc/src/qdrant-client.ts
@@ -1,6 +1,6 @@
-import {GrpcClients, createApis} from './api-client.js';
-import {QdrantClientConfigError} from './errors.js';
-import {ClientVersion, PACKAGE_VERSION} from './client-version.js';
+import { GrpcClients, createApis } from './api-client.js';
+import { QdrantClientConfigError } from './errors.js';
+import { ClientVersion, PACKAGE_VERSION } from './client-version.js';
 
 export type QdrantClientParams = {
     port?: number | null;
@@ -13,6 +13,7 @@ export type QdrantClientParams = {
     checkCompatibility?: boolean;
     compression?: boolean | 'gzip';
     headers?: Record<string, string>;
+    allowUnsecureConnection?: boolean; 
 };
 
 export class QdrantClient {
@@ -35,6 +36,7 @@ export class QdrantClient {
         checkCompatibility = true,
         compression = true,
         headers,
+        allowUnsecureConnection = false, 
     }: QdrantClientParams = {}) {
         this._https = https ?? typeof apiKey === 'string';
         this._scheme = this._https ? 'https' : 'http';
@@ -49,10 +51,11 @@ export class QdrantClient {
                 `Only one of \`url\`, \`host\` params can be set. Url is ${url}, host is ${host}`,
             );
         }
+
         if (host && (host.startsWith('http://') || host.startsWith('https://') || /:\d+$/.test(host))) {
             throw new QdrantClientConfigError(
                 'The `host` param is not expected to contain neither protocol (http:// or https://) nor port (:6333).\n' +
-                    'Try to use the `url` parameter instead.',
+                'Try to use the `url` parameter instead.',
             );
         } else if (url) {
             if (!(url.startsWith('http://') || url.startsWith('https://'))) {
@@ -60,6 +63,7 @@ export class QdrantClient {
                     'The `url` param expected to contain a valid URL starting with a protocol (http:// or https://).',
                 );
             }
+
             const parsedUrl = new URL(url);
             this._host = parsedUrl.hostname;
             this._port = parsedUrl.port ? Number(parsedUrl.port) : port;
@@ -68,7 +72,7 @@ export class QdrantClient {
             if (this._prefix.length > 0 && parsedUrl.pathname !== '/') {
                 throw new QdrantClientConfigError(
                     'Prefix can be set either in `url` or in `prefix`.\n' +
-                        `url is ${url}, prefix is ${parsedUrl.pathname}`,
+                    `url is ${url}, prefix is ${parsedUrl.pathname}`,
                 );
             }
         } else {
@@ -76,8 +80,9 @@ export class QdrantClient {
             this._host = host ?? '127.0.0.1';
         }
 
+        
         if (typeof apiKey === 'string') {
-            if (this._scheme === 'http') {
+            if (this._scheme === 'http' && !allowUnsecureConnection) {
                 console.warn('Api key is used with unsecure connection.');
             }
         }
@@ -85,7 +90,12 @@ export class QdrantClient {
         const address = this._port ? `${this._host}:${this._port}` : this._host;
         this._restUri = `${this._scheme}://${address}${this._prefix}`;
 
-        this._grcpClients = createApis(this._restUri, {apiKey, timeout, compression, headers});
+        this._grcpClients = createApis(this._restUri, {
+            apiKey,
+            timeout,
+            compression,
+            headers,
+        });
 
         if (checkCompatibility) {
             this._grcpClients.service
@@ -108,9 +118,6 @@ export class QdrantClient {
 
     /**
      * API getter
-     *
-     * @param string Name of api
-     * @returns An instance of a namespaced API, generated from grpc services.
      */
     api<T extends keyof GrpcClients>(name: T): GrpcClients[T] {
         return this._grcpClients[name];

--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -33,6 +33,7 @@ export type QdrantClientParams = {
      * Check compatibility with the server version. Default: `true`
      */
     checkCompatibility?: boolean;
+    allowUnsecureConnection?: boolean;
 };
 
 export class QdrantClient {
@@ -53,6 +54,7 @@ export class QdrantClient {
         port = 6333,
         timeout = 300_000,
         checkCompatibility = true,
+        allowUnsecureConnection = false,
         ...args
     }: QdrantClientParams = {}) {
         this._https = https ?? typeof apiKey === 'string';
@@ -105,7 +107,7 @@ export class QdrantClient {
         });
 
         if (typeof apiKey === 'string') {
-            if (this._scheme === 'http') {
+            if (this._scheme === 'http' && !allowUnsecureConnection) {
                 console.warn('Api key is used with unsecure connection.');
             }
             headers.set('api-key', apiKey);


### PR DESCRIPTION
/claim  #119

##  Summary
Adds an optional configuration flag `allowUnsecureConnection` to suppress warnings when API keys are used over unsecure connections.

##  Motivation
In controlled environments (e.g., internal services behind VPN), unsecure connections may be acceptable and warnings can clutter logs.

##  Changes
- Added `allowUnsecureConnection` flag to client configuration
- Updated warning logic in both gRPC and REST clients
- Preserved default behavior

##  Testing
- Verified warning appears when flag is false
- Verified warning is suppressed when flag is true

##  Demo

Tested locally:

Case 1: Default config (allowUnsecureConnection = false)
→ Warning is shown

Case 2: allowUnsecureConnection = true
→ Warning is suppressed

This confirms expected behavior.