### PR TITLE
ci: update GitHub Actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -24,7 +24,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           scope: "@qdrant"
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -24,7 +24,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           scope: "@qdrant"
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v2
         with:
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           scope: "@qdrant"
           node-version: ${{ matrix.node-version }}
@@ -53,7 +53,7 @@ jobs:
       - run: pnpm publish --provenance --no-git-checks --filter '!monorepo'
 
       - name: Archive npm failure logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: npm-logs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@v2
         with:
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           scope: "@qdrant"
           node-version: ${{ matrix.node-version }}
@@ -53,7 +53,7 @@ jobs:
       - run: pnpm publish --provenance --no-git-checks --filter '!monorepo'
 
       - name: Archive npm failure logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}
         with:
           name: npm-logs


### PR DESCRIPTION
## Summary

GitHub will force all JavaScript-based actions to run on Node 24 starting **June 2, 2026**.
Node 20 will be removed from runners entirely on September 16, 2026.

Actions pinned to older versions (v1-v4 for checkout, v2-v5 for setup-python, etc.) were
written for Node 12/16/20 and risk breaking when forced to Node 24.

This PR updates all `actions/*` references to the latest Node 24-native versions.

## Changes

| Action | From | To | Node |
|--------|------|----|------|
| actions/checkout | v1-v4 | v6.0.2 | 24 |
| actions/setup-python | v2-v5 | v6.2.0 | 24 |
| actions/setup-node | v2-v4 | v6.4.0 | 24 |
| actions/setup-go | v4-v5 | v6.4.0 | 24 |
| actions/setup-java | v3 | v5.2.0 | 24 |
| actions/setup-dotnet | v4 | v5.2.0 | 24 |
| actions/cache | v3-v4 | v5.0.5 | 24 |
| actions/upload-artifact | v4 | v7.0.1 | 24 |
| actions/download-artifact | v4-v5 | v8.0.1 | 24 |
| actions/github-script | v7 | v9.0.0 | 24 |

All target SHAs verified against their tags via the GitHub API.
All target versions confirmed running `node24` in their `action.yml`.

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/