### PR TITLE
Fix prepublish for Node 24

### DIFF
--- a/scripts/prepublish.mjs
+++ b/scripts/prepublish.mjs
@@ -1,5 +1,5 @@
-import restClient from '../packages/js-client-rest/package.json' assert {type: 'json'};
-import grpcClient from '../packages/js-client-grpc/package.json' assert {type: 'json'};
+import restClient from '../packages/js-client-rest/package.json' with {type: 'json'};
+import grpcClient from '../packages/js-client-grpc/package.json' with {type: 'json'};
 import {promisify} from 'node:util';
 import {exec} from 'node:child_process';
 


### PR DESCRIPTION
`assert {type: 'json'}` was removed from the language in favour of `with {type: 'json'}`.[ #135/#136](https://github.com/qdrant/qdrant-js/pull/135) moved the workflows to Node 24, but this script only runs on a tag push, so nothing exercised it until the v1.19.0 release died here before `pnpm publish`.
