### PR TITLE
Pass the npm token the way setup-node expects

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,16 +41,10 @@ jobs:
         env:
           CI: 1
 
-      - name: Add registry path to .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - run: node scripts/prepublish.mjs
       - run: pnpm publish --provenance --no-git-checks --filter '!monorepo'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Archive npm failure logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Publishing v1.19.0 failed with `404 Not Found - PUT .../@qdrant%2fjs-client-grpc` on a package that plainly exists. npm answers 404 rather than 401 on an unauthenticated write, so this was an auth failure, not a missing package.

`setup-node` is configured with `scope: "@qdrant"`, and in that mode it writes its own .npmrc to RUNNER_TEMP and exports NPM_CONFIG_USERCONFIG at it. That takes precedence over `$HOME/.npmrc`, so the token this workflow wrote by hand was never read. The file setup-node wrote reads the token from NODE_AUTH_TOKEN instead, and setup-node defaults that variable to the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX` when the workflow does not supply one — so publish authenticated with the placeholder.

Drop the hand-written .npmrc step, which never had any effect, and hand the secret to the publish step as NODE_AUTH_TOKEN.

Nothing about this configuration changed since v1.18.0 published cleanly; what changed was pnpm 9.15.9 -> 11.9.0 (#150) and setup-node v3 -> v6.4.0 (#136). pnpm 9 appears not to have honoured NPM_CONFIG_USERCONFIG, which is why the stray `$HOME/.npmrc` used to be picked up.

Verified by reproducing both sides locally against setup-node's exact .npmrc: without NODE_AUTH_TOKEN pnpm resolves the token to the placeholder, with it set it resolves to the real value.