### PR TITLE
fix: set _prefix from url path when constructing via `url`

### DIFF
--- a/packages/js-client-rest/src/qdrant-client.ts
+++ b/packages/js-client-rest/src/qdrant-client.ts
@@ -90,6 +90,10 @@ export class QdrantClient {
                         `url is ${url}, prefix is ${parsedUrl.pathname}`,
                 );
             }
+
+            if (parsedUrl.pathname !== '/') {
+                this._prefix = parsedUrl.pathname;
+            }
         } else {
             this._port = port;
             this._host = host ?? '127.0.0.1';

--- a/packages/js-client-rest/tests/unit/qdrant-client.test.ts
+++ b/packages/js-client-rest/tests/unit/qdrant-client.test.ts
@@ -4,41 +4,41 @@ import {QdrantClientConfigError} from '../../src/errors.js';
 
 test('QdrantClient()', () => {
     let client = new QdrantClient();
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://127.0.0.1:6333');
 
     client = new QdrantClient({https: true});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('https://127.0.0.1:6333');
 
     client = new QdrantClient({https: true, port: 7333});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('https://127.0.0.1:7333');
 
     expect(() => new QdrantClient({host: 'localhost:6333'})).toThrow(QdrantClientConfigError);
 
     client = new QdrantClient({host: 'hidden_port_addr.com', prefix: 'custom'});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://hidden_port_addr.com:6333/custom');
 
     client = new QdrantClient({host: 'hidden_port_addr.com', port: null});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://hidden_port_addr.com');
 
     client = new QdrantClient({host: 'hidden_port_addr.com', port: null, prefix: 'custom'});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://hidden_port_addr.com/custom');
 
     client = new QdrantClient({url: 'http://hidden_port_addr.com', port: null});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://hidden_port_addr.com');
 
     client = new QdrantClient({url: 'http://localhost:6333', port: 7333});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://localhost:6333');
 
     client = new QdrantClient({url: 'http://localhost:6333', prefix: 'custom'});
-    // @ts-expect-error ts(2341)
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
     expect(client._restUri).toBe('http://localhost:6333/custom');
 
     expect(() => new QdrantClient({url: 'my-domain.com'})).toThrow(QdrantClientConfigError);
@@ -50,4 +50,12 @@ test('QdrantClient()', () => {
     expect(() => new QdrantClient({url: 'http://localhost:6333/origin', prefix: 'custom'})).toThrow(
         QdrantClientConfigError,
     );
+
+    client = new QdrantClient({url: 'http://localhost:6333/origin'});
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
+    expect(client._restUri).toBe('http://localhost:6333/origin');
+
+    client = new QdrantClient({url: 'https://hidden_port_addr.com/qdrant-proxy', port: null});
+    // @ts-expect-error ts(2341) - _restUri is private, accessed here for test assertion
+    expect(client._restUri).toBe('https://hidden_port_addr.com/qdrant-proxy');
 });


### PR DESCRIPTION
## Summary

Closes #104.

`QdrantClient`'s constructor parses `hostname`, `port`, and `protocol` out of the `url` param, but discards `parsedUrl.pathname` entirely. So if you construct a client with a URL that includes a path — e.g. Qdrant running behind a reverse proxy at `https://host/qdrant-proxy` — that path segment is silently dropped from every request instead of being used as the client's `prefix`:

```ts
const client = new QdrantClient({ url: 'https://host/qdrant-proxy' });
// _restUri ends up as 'https://host:6333', not 'https://host:6333/qdrant-proxy'
```

There's an existing PR (#36) open since 2023 for this same issue, using essentially the same one-line fix but against an older version of this file (the constructor has since grown a `prefix`+`url` conflict check). This PR reapplies that fix against current `master` with test coverage.

## Fix

After the existing check that throws when both `prefix` and a path-bearing `url` are set (so we know at this point `_prefix` is either empty or the url's pathname is `'/'`), set `this._prefix = parsedUrl.pathname` whenever the url's pathname isn't just `'/'`.

## Testing

- Added two cases to `qdrant-client.test.ts`: a path-only URL, and a path-bearing URL combined with `port: null`.
- Also added descriptions to the existing `@ts-expect-error` comments in that test file — `lint-staged`'s eslint run lints the whole staged file and `@typescript-eslint/ban-ts-comment` was already failing on all 9 pre-existing occurrences (confirmed via `git stash` against unmodified `master`, unrelated to this change), which blocked the commit. Fixed those too so the pre-commit hook passes cleanly.
- `vitest run tests/unit/qdrant-client.test.ts` — passing.
- `tsc --noEmit`, `knip`, and the full workspace test suite (via the repo's pre-commit hook) — all passing.
- `eslint` — clean.